### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DimensionalPlotRecipes"
 uuid = "c619ae07-58cd-5f6d-b883-8f17bd6a98f9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.4.2"
+version = "1.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Bumps the version(s) below so the src changes already merged to `master` can be registered in the General registry.

- DimensionalPlotRecipes: 1.4.2 -> 1.5.0

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
