### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "Plots,StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,27 @@
+using DimensionalPlotRecipes, Plots, BenchmarkTools
+using StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+x = collect(range(0.0, 10.0, length = 200))
+y_complex = randn(rng, 200, 10) .+ im .* randn(rng, 200, 10)
+
+# =============================================================================
+# Recipe transformations through the Plots pipeline
+# =============================================================================
+
+SUITE["recipes"] = BenchmarkGroup()
+
+SUITE["recipes"]["split3D"] = @benchmarkable plot(
+    $x, $y_complex; transformation = :split3D
+)
+SUITE["recipes"]["split2D"] = @benchmarkable plot(
+    $x, $y_complex; transformation = :split2D
+)
+SUITE["recipes"]["modulus"] = @benchmarkable plot(
+    $x, $y_complex; transformation = :modulus
+)
+SUITE["recipes"]["modulus2"] = @benchmarkable plot(
+    $x, $y_complex; transformation = :modulus2
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~29s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~29s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md